### PR TITLE
Move ci to flatiron institute

### DIFF
--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -58,10 +58,10 @@ def isBuildAReplay() {
 
 def verifyChanges(String sourceCodePaths) {
 
-    sh("""
+    sh """
         git config user.email "mc.stanislaw@gmail.com"
         git config user.name "Stan Jenkins"
-    """)
+    """
 
     def commitHash = ""
     def changeTarget = ""
@@ -75,9 +75,10 @@ def verifyChanges(String sourceCodePaths) {
         currentRepository = sh(script: "echo ${env.CHANGE_URL} | cut -d'/' -f 5", returnStdout: true)
     }
 
+    sh(script: "git submodule update --init --recursive", returnStdout: true)
     sh(script: "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' --replace-all", returnStdout: true)
     sh(script: "git remote rm forkedOrigin || true", returnStdout: true)
-    sh(script: "git fetch --all --no-recurse-submodules", returnStdout: true)
+    sh(script: "git fetch --all", returnStdout: true)
 
     if (env.CHANGE_TARGET) {
         println "This build is a PR, checking out target branch to compare changes."

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -58,6 +58,11 @@ def isBuildAReplay() {
 
 def verifyChanges(String sourceCodePaths) {
 
+    sh("""
+        git config --global user.email "mc.stanislaw@gmail.com"
+        git config --global user.name "Stan Jenkins"
+    """)
+
     def commitHash = ""
     def changeTarget = ""
     def currentRepository = ""
@@ -80,11 +85,6 @@ def verifyChanges(String sourceCodePaths) {
 
         if (env.CHANGE_FORK) {
             println "This PR is a fork."
-
-            sh("""
-                git config --global user.email "mc.stanislaw@gmail.com"
-                git config --global user.name "Stan Jenkins"
-            """)
 
             withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b', usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
                 sh """#!/bin/bash

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -5,16 +5,11 @@ import jenkins.model.CauseOfInterruption.UserInterruption
 
 def killOldBuilds() {
   def hi = Hudson.instance
-  def pname = env.JOB_NAME.split('/')[0]
+  def rootProject = env.JOB_NAME.split('/')[0]
+  def secondaryProject = env.JOB_NAME.split('/')[1]
+  def targetBranchOrPR = env.CHANGE_ID?.trim() ? "PR-" + env.CHANGE_ID : env.BRANCH_NAME
 
-  println("---")
-  println(pname)
-  println(env.JOB_NAME)
-  println(env.JOB_BASE_NAME)
-  println(env.JOB_URL)
-  println("---")
-
-  hi.getItem(pname).getItem(env.JOB_BASE_NAME).getBuilds().each{ build ->
+  hi.getItem(rootProject).getItem(secondaryProject).getItem(targetBranchOrPR).getBuilds().each{ build ->
     def exec = build.getExecutor()
 
     if (build.number != currentBuild.number && exec != null) {
@@ -27,6 +22,7 @@ def killOldBuilds() {
       println("Aborted previous running build #${build.number}")
     }
   }
+
 }
 
 def isBranch(env, String b) { env.BRANCH_NAME == b }

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -59,8 +59,8 @@ def isBuildAReplay() {
 def verifyChanges(String sourceCodePaths) {
 
     sh("""
-        git config --global user.email "mc.stanislaw@gmail.com"
-        git config --global user.name "Stan Jenkins"
+        git config user.email "mc.stanislaw@gmail.com"
+        git config user.name "Stan Jenkins"
     """)
 
     def commitHash = ""

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -75,10 +75,10 @@ def verifyChanges(String sourceCodePaths) {
         currentRepository = sh(script: "echo ${env.CHANGE_URL} | cut -d'/' -f 5", returnStdout: true)
     }
 
-    sh(script: "git submodule update --init --recursive", returnStdout: true)
+    sh(script: "git submodule update --init --recursive --remote", returnStdout: true)
     sh(script: "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' --replace-all", returnStdout: true)
     sh(script: "git remote rm forkedOrigin || true", returnStdout: true)
-    sh(script: "git fetch --all", returnStdout: true)
+    sh(script: "git fetch --all --recurse-submodules=yes", returnStdout: true)
 
     if (env.CHANGE_TARGET) {
         println "This build is a PR, checking out target branch to compare changes."

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -77,7 +77,7 @@ def verifyChanges(String sourceCodePaths) {
 
     sh(script: "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' --replace-all", returnStdout: true)
     sh(script: "git remote rm forkedOrigin || true", returnStdout: true)
-    sh(script: "git fetch --all", returnStdout: true)
+    sh(script: "git fetch --all || true", returnStdout: true)
 
     if (env.CHANGE_TARGET) {
         println "This build is a PR, checking out target branch to compare changes."

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -67,7 +67,6 @@ def verifyChanges(String sourceCodePaths) {
         currentRepository = sh(script: "echo ${env.CHANGE_URL} | cut -d'/' -f 5", returnStdout: true)
     }
 
-    sh(script:"ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts", returnStdout: false)
     sh(script: "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' --replace-all", returnStdout: true)
     sh(script: "git remote rm forkedOrigin || true", returnStdout: true)
     sh(script: "git fetch --all", returnStdout: true)

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -7,6 +7,8 @@ def killOldBuilds() {
   def hi = Hudson.instance
   def pname = env.JOB_NAME.split('/')[0]
 
+  println(pname)
+
   hi.getItem(pname).getItem(env.JOB_BASE_NAME).getBuilds().each{ build ->
     def exec = build.getExecutor()
 

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -77,7 +77,7 @@ def verifyChanges(String sourceCodePaths) {
 
     sh(script: "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' --replace-all", returnStdout: true)
     sh(script: "git remote rm forkedOrigin || true", returnStdout: true)
-    sh(script: "git fetch --all", returnStdout: true)
+    sh(script: "git fetch --all --no-recurse-submodules", returnStdout: true)
 
     if (env.CHANGE_TARGET) {
         println "This build is a PR, checking out target branch to compare changes."

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -7,8 +7,12 @@ def killOldBuilds() {
   def hi = Hudson.instance
   def pname = env.JOB_NAME.split('/')[0]
 
+  println("---")
   println(pname)
+  println(env.JOB_NAME)
   println(env.JOB_BASE_NAME)
+  println(env.JOB_URL)
+  println("---")
 
   hi.getItem(pname).getItem(env.JOB_BASE_NAME).getBuilds().each{ build ->
     def exec = build.getExecutor()

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -75,10 +75,9 @@ def verifyChanges(String sourceCodePaths) {
         currentRepository = sh(script: "echo ${env.CHANGE_URL} | cut -d'/' -f 5", returnStdout: true)
     }
 
-    sh(script: "git submodule update --init --recursive --remote", returnStdout: true)
     sh(script: "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' --replace-all", returnStdout: true)
     sh(script: "git remote rm forkedOrigin || true", returnStdout: true)
-    sh(script: "git fetch --all --recurse-submodules=yes", returnStdout: true)
+    sh(script: "git fetch --all", returnStdout: true)
 
     if (env.CHANGE_TARGET) {
         println "This build is a PR, checking out target branch to compare changes."

--- a/src/org/stan/Utils.groovy
+++ b/src/org/stan/Utils.groovy
@@ -8,6 +8,7 @@ def killOldBuilds() {
   def pname = env.JOB_NAME.split('/')[0]
 
   println(pname)
+  println(env.JOB_BASE_NAME)
 
   hi.getItem(pname).getItem(env.JOB_BASE_NAME).getBuilds().each{ build ->
     def exec = build.getExecutor()


### PR DESCRIPTION
## Summary

This PR will handle Jenkins CI migration to Flatiron Institute. Currently WIP until we iron out errors, plugins and other requirements.

## Tests

We will run mc-stan and flatiron Jenkins in parallel until it's stable and most of the main jobs are workings, after that we will decomission mc-stan and migrate entirely to Flatiron Institute.

## Side Effects

There may be side effects where two jobs would try to do the same objective like updating a submodule, will try to avoid this as much as possible.
